### PR TITLE
Add system diagram document

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,3 +23,35 @@ See [CONTRIBUTING](CONTRIBUTING.md#security-issue-notifications) for more inform
 ## License
 
 This library is licensed under the MIT-0 License. See the LICENSE file.
+## Data Logger Architecture
+
+The project includes a simple data logger that records order and pricing information. Logs are stored in the `data/logger` directory.
+
+### System Diagram
+
+```mermaid
+graph TD
+    SNAP_Bundle[Customer Order: SNAP Bundle]
+    DataLogger[DATA LOGGER]
+    PriceAPI[Real-Time Grocery Price Feeds]
+    CostModule[COGS Breakdown Module]
+    ComparisonEngine[Comparison Engine]
+    KPIDashboard[LIVE KPI DASHBOARD]
+    GeminiAI[Gemini Validator]
+    DeepSeekAI[DeepSeek Optimizer]
+
+    SNAP_Bundle --> DataLogger
+    DataLogger --> CostModule
+    CostModule --> ComparisonEngine
+    PriceAPI --> ComparisonEngine
+    ComparisonEngine --> KPIDashboard
+    KPIDashboard --> GeminiAI
+    KPIDashboard --> DeepSeekAI
+```
+
+### Adding Logs
+
+1. Place JSON log files into `data/logger`. See `data/logger/README.md` for format details.
+2. Each log should capture the customer order, prices pulled from the API, and any processed KPI results.
+
+These logs can later be processed by analytics tools or uploaded to your data warehouse.

--- a/data/logger/README.md
+++ b/data/logger/README.md
@@ -1,0 +1,17 @@
+# Data Logger
+
+This folder stores raw data captured from the application. Each log file should be in JSON format with a timestamped filename.
+
+Example log file structure:
+```json
+{
+  "timestamp": "2024-01-01T00:00:00Z",
+  "customerOrder": {
+    "bundleType": "SNAP Bundle",
+    "items": [/* ... */]
+  },
+  "groceryPrices": [/* ... */]
+}
+```
+
+For a visual overview of how these logs integrate with other modules, see [../docs/system_diagram.md](../docs/system_diagram.md).

--- a/docs/system_diagram.md
+++ b/docs/system_diagram.md
@@ -1,0 +1,25 @@
+# Data Flow Diagram
+
+The following Mermaid diagram illustrates the relationship between the data logger and related modules used in this project.
+
+```mermaid
+graph TD
+    SNAP_Bundle[Customer Order: SNAP Bundle]
+    DataLogger[DATA LOGGER]
+    PriceAPI[Real-Time Grocery Price Feeds]
+    CostModule[COGS Breakdown Module]
+    ComparisonEngine[Comparison Engine]
+    KPIDashboard[LIVE KPI DASHBOARD]
+    GeminiAI[Gemini Validator]
+    DeepSeekAI[DeepSeek Optimizer]
+
+    SNAP_Bundle --> DataLogger
+    DataLogger --> CostModule
+    CostModule --> ComparisonEngine
+    PriceAPI --> ComparisonEngine
+    ComparisonEngine --> KPIDashboard
+    KPIDashboard --> GeminiAI
+    KPIDashboard --> DeepSeekAI
+```
+
+This diagram matches the architecture described in the main `README.md` and is provided here for easy reference.


### PR DESCRIPTION
## Summary
- add system diagram with mermaid diagram showing data logger flow
- reference the diagram from data logger readme

## Testing
- `npm run lint` *(fails: couldn't find eslint config)*

------
https://chatgpt.com/codex/tasks/task_b_683afb50997083328adf88f751247ab4