### PR TITLE
Add log schema and validation tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,3 +23,36 @@ See [CONTRIBUTING](CONTRIBUTING.md#security-issue-notifications) for more inform
 ## License
 
 This library is licensed under the MIT-0 License. See the LICENSE file.
+## Data Logger Architecture
+
+The project includes a simple data logger that records order and pricing information. Logs are stored in the `data/logger` directory.
+
+### System Diagram
+
+```mermaid
+graph TD
+    SNAP_Bundle[Customer Order: SNAP Bundle]
+    DataLogger[DATA LOGGER]
+    PriceAPI[Real-Time Grocery Price Feeds]
+    CostModule[COGS Breakdown Module]
+    ComparisonEngine[Comparison Engine]
+    KPIDashboard[LIVE KPI DASHBOARD]
+    GeminiAI[Gemini Validator]
+    DeepSeekAI[DeepSeek Optimizer]
+
+    SNAP_Bundle --> DataLogger
+    DataLogger --> CostModule
+    CostModule --> ComparisonEngine
+    PriceAPI --> ComparisonEngine
+    ComparisonEngine --> KPIDashboard
+    KPIDashboard --> GeminiAI
+    KPIDashboard --> DeepSeekAI
+```
+
+### Adding Logs
+
+1. Place JSON log files into `data/logger`. See `data/logger/README.md` for format details.
+2. Each log should capture the customer order, prices pulled from the API, and any processed KPI results.
+3. Run `python data/logger/validate_log.py` to ensure all log files match the expected schema before using them in other modules.
+
+These logs can later be processed by analytics tools or uploaded to your data warehouse.

--- a/data/logger/README.md
+++ b/data/logger/README.md
@@ -1,0 +1,51 @@
+# Data Logger
+
+This directory stores operational logs used by the pricing and KPI system. Every log must be a JSON file that conforms to the schema below. Files that fail validation will be rejected by downstream modules.
+
+## Required Fields
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `timestamp` | ISO 8601 | Time the order was logged (UTC). |
+| `customer_id` | String | Unique customer identifier. |
+| `bundle_id` | String | Reference to the bundle purchased. |
+| `price_pulled` | Float | Final price from the pricing API. |
+| `processed_kpis` | Object | Metrics generated after processing. |
+
+### `processed_kpis` Fields
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `margin` | Float | Net margin after all costs. |
+| `delivery_cost` | Float | Cost to deliver the bundle. |
+| `snap_multiplier` | Float | Multiplier applied for EBT bundles. |
+| `bundle_passed` | Boolean | Whether the bundle cleared margin rules. |
+
+## Example Log
+
+```json
+{
+  "timestamp": "2025-05-31T10:00:00Z",
+  "customer_id": "ABC123",
+  "bundle_id": "SNAP20",
+  "price_pulled": 19.99,
+  "processed_kpis": {
+    "margin": 0.28,
+    "delivery_cost": 3.50,
+    "snap_multiplier": 1.25,
+    "bundle_passed": true
+  }
+}
+```
+
+A starter template is provided in `log_template.json`.
+
+## Validation
+
+Run `validate_log.py` to verify all log files:
+
+```bash
+python validate_log.py
+```
+
+The script checks each JSON file in this directory for required fields and correct types. It prints `PASS` for valid logs or an error message describing any issues.

--- a/data/logger/log_template.json
+++ b/data/logger/log_template.json
@@ -1,0 +1,12 @@
+{
+  "timestamp": "YYYY-MM-DDTHH:MM:SSZ",
+  "customer_id": "CUSTOMER_ID_HERE",
+  "bundle_id": "BUNDLE_CODE",
+  "price_pulled": 0.00,
+  "processed_kpis": {
+    "margin": 0.00,
+    "delivery_cost": 0.00,
+    "snap_multiplier": 0.00,
+    "bundle_passed": false
+  }
+}

--- a/data/logger/validate_log.py
+++ b/data/logger/validate_log.py
@@ -1,0 +1,63 @@
+import json
+import os
+import datetime
+
+REQUIRED_FIELDS = {
+    "timestamp": str,
+    "customer_id": str,
+    "bundle_id": str,
+    "price_pulled": float,
+    "processed_kpis": dict
+}
+
+KPI_FIELDS = {
+    "margin": float,
+    "delivery_cost": float,
+    "snap_multiplier": float,
+    "bundle_passed": bool
+}
+
+def validate_iso8601(ts):
+    try:
+        datetime.datetime.fromisoformat(ts.replace("Z", "+00:00"))
+        return True
+    except ValueError:
+        return False
+
+def validate_file(filepath):
+    try:
+        with open(filepath, 'r') as f:
+            data = json.load(f)
+
+        for field, ftype in REQUIRED_FIELDS.items():
+            if field not in data:
+                return f"Missing field: {field}"
+            if not isinstance(data[field], ftype) and not (field == "price_pulled" and isinstance(data[field], (float, int))):
+                return f"Invalid type for {field}, expected {ftype.__name__}"
+
+        if not validate_iso8601(data["timestamp"]):
+            return "Invalid ISO 8601 timestamp format"
+
+        kpis = data["processed_kpis"]
+        for kfield, ktype in KPI_FIELDS.items():
+            if kfield not in kpis:
+                return f"Missing KPI field: {kfield}"
+            if not isinstance(kpis[kfield], ktype) and not (ktype == float and isinstance(kpis[kfield], int)):
+                return f"Invalid type for KPI.{kfield}, expected {ktype.__name__}"
+
+        return "PASS"
+
+    except Exception as e:
+        return f"ERROR: {str(e)}"
+
+
+def main():
+    log_dir = os.path.dirname(__file__)
+    for filename in os.listdir(log_dir):
+        if filename.endswith(".json"):
+            path = os.path.join(log_dir, filename)
+            result = validate_file(path)
+            print(f"{filename}: {result}")
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- expand instructions in data logger README with required fields
- add a JSON template for new logs
- provide a Python script for validating log files
- mention validation step in main README

## Testing
- `npm run lint` *(fails: ESLint couldn't find a config file)*
- `python data/logger/validate_log.py` *(shows invalid placeholder timestamp in template)*

------
https://chatgpt.com/codex/tasks/task_b_683afb50997083328adf88f751247ab4

## Summary by Sourcery

Add log schema definition and validation tooling for the data logger.

New Features:
- Provide a Python script to validate JSON log files against a defined schema.
- Include a JSON template for creating new log entries.

Enhancements:
- Mention the validation step in the main README instructions.

Documentation:
- Expand the main README with a Data Logger architecture diagram and usage instructions.
- Add a dedicated README in data/logger detailing required fields and an example log.