### PR TITLE
Add system diagram docs and dataset layout

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,3 +23,43 @@ See [CONTRIBUTING](CONTRIBUTING.md#security-issue-notifications) for more inform
 ## License
 
 This library is licensed under the MIT-0 License. See the LICENSE file.
+## Data Logger Architecture
+
+The project includes a simple data logger that records order and pricing information. Logs are stored in the `data/logger` directory.
+
+### System Diagram
+
+```mermaid
+graph TD
+    SNAP_Bundle[Customer Order: SNAP Bundle]
+    DataLogger[DATA LOGGER]
+    PriceAPI[Real-Time Grocery Price Feeds]
+    CostModule[COGS Breakdown Module]
+    ComparisonEngine[Comparison Engine]
+    KPIDashboard[LIVE KPI DASHBOARD]
+    GeminiAI[Gemini Validator]
+    DeepSeekAI[DeepSeek Optimizer]
+
+    SNAP_Bundle --> DataLogger
+    DataLogger --> CostModule
+    CostModule --> ComparisonEngine
+    PriceAPI --> ComparisonEngine
+    ComparisonEngine --> KPIDashboard
+    KPIDashboard --> GeminiAI
+    KPIDashboard --> DeepSeekAI
+```
+
+### Adding Logs
+
+1. Place JSON log files into `data/logger`. See `data/logger/README.md` for format details.
+2. Each log should capture the customer order, prices pulled from the API, and any processed KPI results.
+
+These logs can later be processed by analytics tools or uploaded to your data warehouse.
+
+### Dataset Layout
+The `data/logger` folder organizes raw data for analysis:
+- `raw_data/` – location metrics, orders, staffing, and financial CSVs
+- `trigger_logs/` – grant eligibility snapshots and investor signals
+- `quant_search/` – reference data from USDA, MBDA, and other funding searches
+
+See `docs/system_diagram.md` for how these datasets connect to the rest of the platform.

--- a/data/logger/README.md
+++ b/data/logger/README.md
@@ -1,0 +1,23 @@
+# Data Logger
+
+This folder stores operational logs used by the analytics pipeline. All files must be valid JSON.
+
+## Subfolders
+
+- `raw_data/` – daily operational CSVs such as location metrics and orders
+- `trigger_logs/` – snapshots of grant eligibility or investor signals
+- `quant_search/` – raw responses from external funding or accelerator searches
+
+See the [system diagram](../docs/system_diagram.md) for how these logs flow through the platform.
+
+### Example log entry
+```json
+{
+  "timestamp": "2024-01-01T00:00:00Z",
+  "customerOrder": {
+    "bundleType": "SNAP Bundle",
+    "items": []
+  },
+  "groceryPrices": []
+}
+```

--- a/docs/system_diagram.md
+++ b/docs/system_diagram.md
@@ -1,0 +1,23 @@
+# System Diagram
+
+The data logger interacts with pricing, cost, and KPI modules to feed analytics dashboards.
+
+```mermaid
+graph TD
+    SNAP_Bundle[Customer Order: SNAP Bundle]
+    DataLogger[DATA LOGGER]
+    PriceAPI[Real-Time Grocery Price Feeds]
+    CostModule[COGS Breakdown Module]
+    ComparisonEngine[Comparison Engine]
+    KPIDashboard[LIVE KPI DASHBOARD]
+    GeminiAI[Gemini Validator]
+    DeepSeekAI[DeepSeek Optimizer]
+
+    SNAP_Bundle --> DataLogger
+    DataLogger --> CostModule
+    CostModule --> ComparisonEngine
+    PriceAPI --> ComparisonEngine
+    ComparisonEngine --> KPIDashboard
+    KPIDashboard --> GeminiAI
+    KPIDashboard --> DeepSeekAI
+```


### PR DESCRIPTION
## Summary
- document dataset subfolders in `data/logger/README.md`
- add system diagram reference and dataset layout to the main README
- create `docs/system_diagram.md` with the data flow diagram

## Testing
- `npm run lint` *(fails: no eslint config)*

------
https://chatgpt.com/codex/tasks/task_b_683afb50997083328adf88f751247ab4