### PR TITLE
Add enterprise data logger blueprint

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,3 +23,36 @@ See [CONTRIBUTING](CONTRIBUTING.md#security-issue-notifications) for more inform
 ## License
 
 This library is licensed under the MIT-0 License. See the LICENSE file.
+## Data Logger Architecture
+
+The project includes a simple data logger that records order and pricing information. Logs are stored in the `data/logger` directory.
+
+### System Diagram
+
+```mermaid
+graph TD
+    SNAP_Bundle[Customer Order: SNAP Bundle]
+    DataLogger[DATA LOGGER]
+    PriceAPI[Real-Time Grocery Price Feeds]
+    CostModule[COGS Breakdown Module]
+    ComparisonEngine[Comparison Engine]
+    KPIDashboard[LIVE KPI DASHBOARD]
+    GeminiAI[Gemini Validator]
+    DeepSeekAI[DeepSeek Optimizer]
+
+    SNAP_Bundle --> DataLogger
+    DataLogger --> CostModule
+    CostModule --> ComparisonEngine
+    PriceAPI --> ComparisonEngine
+    ComparisonEngine --> KPIDashboard
+    KPIDashboard --> GeminiAI
+    KPIDashboard --> DeepSeekAI
+```
+
+### Adding Logs
+
+1. Place JSON log files into `data/logger`. See `data/logger/README.md` for format details.
+2. Each log should capture the customer order, prices pulled from the API, and any processed KPI results.
+
+These logs can later be processed by analytics tools or uploaded to your data warehouse.
+For a detailed architecture overview, see [docs/enterprise_data_logger_blueprint.md](docs/enterprise_data_logger_blueprint.md).

--- a/data/logger/README.md
+++ b/data/logger/README.md
@@ -1,0 +1,15 @@
+# Data Logger
+
+This folder stores raw data captured from the application. Each log file should be in JSON format with a timestamped filename.
+
+Example log file structure:
+```json
+{
+  "timestamp": "2024-01-01T00:00:00Z",
+  "customerOrder": {
+    "bundleType": "SNAP Bundle",
+    "items": [/* ... */]
+  },
+  "groceryPrices": [/* ... */]
+}
+```

--- a/docs/enterprise_data_logger_blueprint.md
+++ b/docs/enterprise_data_logger_blueprint.md
@@ -1,0 +1,44 @@
+# Enterprise-Grade Data Logger Blueprint
+
+This document summarizes the planned architecture for a robust data logging system that supports real-time ingestion, AI-driven analysis and actionable business intelligence.
+
+## Purpose
+
+The logger is intended to collect operational data across the platform and provide continuous security, performance and business insights. It goes beyond simple storage by enabling automated processing and daily reporting.
+
+## Key Capabilities
+
+- **Real-time ingestion** using webhooks and APIs.
+- **AI-driven processing** leveraging LLMs (Gemini and DeepSeek) for anomaly detection, summarisation and automated updates.
+- **Actionable analytics** via quantitative formulas ("Quantz") to generate KPIs and predictive insights.
+
+## Architecture Overview
+
+| Layer | Technology Examples | Purpose |
+| --- | --- | --- |
+| Ingestion | Webhooks, REST/GraphQL APIs, Kafka | Capture high-volume data streams |
+| Processing | Apache Spark/Flink, message queues | Transform and enrich data in real time |
+| Storage | Data lake (S3, ADLS) and warehouse (Redshift, BigQuery) | Store raw logs and structured datasets |
+| Analytics | Grafana/Looker/Tableau plus LLM APIs | Visualize metrics and generate daily summaries |
+| Security | IAM, encryption, API governance | Protect data and enforce compliance |
+
+## Data Quality KPIs
+
+To ensure reliable analytics, the following metrics should be tracked:
+
+- **Completeness** – percentage of required fields populated.
+- **Uniqueness** – detection of duplicate records.
+- **Consistency** – adherence to defined schemas across systems.
+- **Timeliness** – how quickly data becomes available for analysis.
+- **Validity** – conformance to expected formats and rules.
+- **Accuracy** – correctness of values captured.
+
+## Operational Recommendations
+
+1. Use structured JSON logging to simplify downstream processing.
+2. Store logs in a central location separate from production systems.
+3. Implement retry mechanisms and idempotent operations for webhook delivery.
+4. Schedule LLM summarisation jobs during off‑peak hours to reduce cost.
+5. Continuously monitor system health and data quality with automated alerts.
+
+This blueprint serves as a starting point for implementation. Future iterations can expand on ETL details, security policies and additional KPIs as the system evolves.


### PR DESCRIPTION
## Summary
- add docs/enterprise_data_logger_blueprint.md outlining a scalable logging system
- reference the blueprint from the main README

## Testing
- `npm run lint` *(fails: ESLint couldn't find a configuration file)*

------
https://chatgpt.com/codex/tasks/task_b_683afb50997083328adf88f751247ab4

## Summary by Sourcery

Introduce an enterprise-grade data logger blueprint and integrate it into project documentation to guide logging architecture and usage.

Documentation:
- Add enterprise_data_logger_blueprint.md outlining robust data logging system architecture, capabilities, and operational recommendations
- Introduce Data Logger Architecture section to README with system diagram and log file usage instructions
- Add data/logger/README.md detailing JSON log file structure and placement guidelines