### PR TITLE
Add file upload datalogger

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,3 +27,6 @@ dist-ssr
 .amplify
 amplify_outputs*
 amplifyconfiguration*
+
+# Datalogger uploads
+uploads/

--- a/README.md
+++ b/README.md
@@ -23,3 +23,20 @@ See [CONTRIBUTING](CONTRIBUTING.md#security-issue-notifications) for more inform
 ## License
 
 This library is licensed under the MIT-0 License. See the LICENSE file.
+
+## Local Datalogger
+
+This project includes a minimal file upload server for local development.
+
+### Running
+
+1. Install dependencies (requires network access):
+   ```bash
+   npm install
+   ```
+2. Start the datalogger:
+   ```bash
+   npm run datalogger
+   ```
+
+Files uploaded to the `/upload` endpoint will be stored in the `uploads/` folder.

--- a/datalogger.js
+++ b/datalogger.js
@@ -1,0 +1,35 @@
+import express from 'express';
+import multer from 'multer';
+import path from 'path';
+import fs from 'fs';
+
+const app = express();
+const port = process.env.PORT || 3000;
+
+const uploadDir = path.join(process.cwd(), 'uploads');
+if (!fs.existsSync(uploadDir)) {
+  fs.mkdirSync(uploadDir, { recursive: true });
+}
+
+const storage = multer.diskStorage({
+  destination: (req, file, cb) => {
+    cb(null, uploadDir);
+  },
+  filename: (req, file, cb) => {
+    cb(null, Date.now() + '-' + file.originalname);
+  }
+});
+const upload = multer({ storage });
+
+app.post('/upload', upload.single('file'), (req, res) => {
+  if (!req.file) {
+    return res.status(400).send('No file uploaded.');
+  }
+  res.send(`File saved to ${req.file.path}`);
+});
+
+app.use('/files', express.static(uploadDir));
+
+app.listen(port, () => {
+  console.log(`Datalogger listening on port ${port}`);
+});

--- a/package.json
+++ b/package.json
@@ -7,13 +7,16 @@
     "dev": "vite",
     "build": "tsc && vite build",
     "lint": "eslint . --ext ts,tsx --report-unused-disable-directives --max-warnings 0",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "datalogger": "node datalogger.js"
   },
   "dependencies": {
     "@aws-amplify/ui-react": "^6.5.5",
     "aws-amplify": "^6.6.6",
     "react": "^18.2.0",
-    "react-dom": "^18.2.0"
+    "react-dom": "^18.2.0",
+    "express": "^4.19.2",
+    "multer": "^1.4.5"
   },
   "devDependencies": {
     "@aws-amplify/backend": "^1.5.0",


### PR DESCRIPTION
## Summary
- implement a simple Express server for uploads
- allow running it via `npm run datalogger`
- track datalogger dependencies in `package.json`
- document how to use the datalogger
- ignore uploaded files in git

## Testing
- `npm run lint` *(fails: ESLint couldn't find configuration)*
- `npm run build` *(fails: missing dependencies)*

------
https://chatgpt.com/codex/tasks/task_b_6838b9eb5b708332821ad045ee2b4e72