### PR TITLE
Add LLM integration resources

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,3 +56,25 @@ graph TD
 3. Run `python data/logger/validate_log.py` to ensure all log files match the expected schema before using them in other modules.
 
 These logs can later be processed by analytics tools or uploaded to your data warehouse.
+
+## LLM Command Center
+
+This project now includes specialized folders for integrating with large language models such as **Gemini Ultra**, **DeepSeek**, and **Mariner**. Use these resources to audit data, trigger prompts, and map incoming information into consistent formats.
+
+### Folder Overview
+
+- **`schemas/`** – JSON and YAML schemas defining the structure of logs and API payloads.
+- **`prompts/`** – Prompt templates and auto-tagging rules for LLM-driven analysis.
+- **`maps/`** – Mapping files to translate raw data into the formats expected by your schemas and prompts.
+
+### Quant Logic Formats
+
+Schemas and maps support JSON and CSV ingestions. KPI fields such as margin, delivery cost, and multipliers are validated against `schemas/data_audit_schema.json`.
+
+### Next Steps for Auto‑Tagging
+
+1. Define additional rules in `prompts/triggers.json` to tag records based on KPI thresholds.
+2. Point your ingestion pipeline to the `maps/ingestion_map.yaml` file so new data aligns with the schemas.
+3. Customize `prompts/sample_prompt.md` or create new prompts for the actions you wish to automate.
+
+These resources can be activated immediately with your LLM provider of choice to streamline reporting and anomaly detection.

--- a/maps/README.md
+++ b/maps/README.md
@@ -1,0 +1,8 @@
+# Maps
+
+Mapping configurations and reference tables used to translate incoming data into formats optimized for Firebase and LLM ingestion. These files help connect your raw data with prompts and schemas.
+
+## Contents
+- `ingestion_map.yaml` – example mapping of CSV columns to schema fields.
+
+Extend this directory with additional mappings as your data sources grow.

--- a/maps/ingestion_map.yaml
+++ b/maps/ingestion_map.yaml
@@ -1,0 +1,8 @@
+tables:
+  orders:
+    csv_columns:
+      - timestamp
+      - customer_id
+      - bundle_id
+      - price_pulled
+    schema: ../schemas/data_audit_schema.json

--- a/prompts/README.md
+++ b/prompts/README.md
@@ -1,0 +1,9 @@
+# Prompts
+
+This directory contains language model prompt templates and trigger definitions. Use these prompts to automate analyses, generate reports, or integrate with Gemini Ultra and DeepSeek.
+
+## Contents
+- `sample_prompt.md` – example prompt structure including variables for dynamic values.
+- `triggers.json` – JSON describing conditions for auto-tagging and prompt execution.
+
+Prompts should be concise yet precise, following best practices for LLM alignment and safety. Adjust variables as needed to suit your data and workflows.

--- a/prompts/sample_prompt.md
+++ b/prompts/sample_prompt.md
@@ -1,0 +1,8 @@
+## Sample Prompt
+
+```
+You are an auditing assistant. Given the following order log:
+{{order_json}}
+
+Analyze the KPIs and produce a concise summary of margin performance. Highlight any anomalies.
+```

--- a/prompts/triggers.json
+++ b/prompts/triggers.json
@@ -1,0 +1,16 @@
+{
+  "auto_tag_rules": [
+    {
+      "field": "processed_kpis.margin",
+      "condition": "<",
+      "value": 0.2,
+      "tag": "low-margin"
+    }
+  ],
+  "prompt_execution": [
+    {
+      "trigger_tag": "low-margin",
+      "prompt_file": "sample_prompt.md"
+    }
+  ]
+}

--- a/schemas/README.md
+++ b/schemas/README.md
@@ -1,0 +1,9 @@
+# Schemas
+
+This directory stores JSON and YAML schema definitions for data ingestion and validation. Schemas ensure that incoming data conforms to expected formats before being processed by Gemini, DeepSeek, and related LLM workflows.
+
+## Contents
+- `data_audit_schema.json` – baseline schema describing required fields for order and KPI logs.
+- Additional schemas for APIs and CSV transforms can be added here.
+
+Use these schemas with your ingestion tools to validate data before running analytics or feeding it into language models.

--- a/schemas/data_audit_schema.json
+++ b/schemas/data_audit_schema.json
@@ -1,0 +1,22 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "Data Audit Log",
+  "type": "object",
+  "required": ["timestamp", "customer_id", "bundle_id", "price_pulled", "processed_kpis"],
+  "properties": {
+    "timestamp": {"type": "string", "format": "date-time"},
+    "customer_id": {"type": "string"},
+    "bundle_id": {"type": "string"},
+    "price_pulled": {"type": "number"},
+    "processed_kpis": {
+      "type": "object",
+      "required": ["margin", "delivery_cost", "snap_multiplier", "bundle_passed"],
+      "properties": {
+        "margin": {"type": "number"},
+        "delivery_cost": {"type": "number"},
+        "snap_multiplier": {"type": "number"},
+        "bundle_passed": {"type": "boolean"}
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- create `schemas`, `prompts`, and `maps` directories
- provide example schema, prompt files, and mapping config
- document new folders in the README as an LLM command center

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_b_68416025b0cc8332bc74a99e67ac81eb

## Summary by Sourcery

Add a new LLM Command Center with dedicated schemas, prompts, and maps directories to integrate with large language models, including example configurations and updated documentation.

New Features:
- Add `schemas`, `prompts`, and `maps` directories to support LLM integration
- Provide example schema definitions, prompt templates, and mapping configurations for data ingestion and auto-tagging

Documentation:
- Document the LLM Command Center and folder structure in the main README
- Add detailed READMEs in `schemas/`, `prompts/`, and `maps/` directories