### PR TITLE
Add NLM pipeline documentation

### DIFF
--- a/README.nlm.md
+++ b/README.nlm.md
@@ -1,0 +1,31 @@
+# Natural Language Feedback Pipeline
+
+This guide outlines a basic flow for analyzing customer feedback or log entries with an emotional and logic based approach. The goal is to quickly detect sentiment, extract key concerns, and feed the results into dashboards or downstream modules.
+
+## Pipeline Overview
+
+1. **Ingest** raw text from `data/logger` files, support emails, or chat logs.
+2. **Preprocess** the text: remove personally identifiable information, normalize spelling, and segment by sentence.
+3. **Emotion Scoring** using a language model such as Gemini. Each entry receives a score from -5 (very negative) to +5 (very positive).
+4. **Logic Classification** where the same model labels common issue types like _billing_, _delivery_, or _website usability_.
+5. **Store** results along with the original log so that trends can be visualized in a KPI dashboard.
+
+## Sample Prompts
+
+### Gemini Sentiment Prompt
+```
+You are an AI assistant that reviews user comments for tone and intent.
+Rate the emotional tone from -5 (very negative) to +5 (very positive) and
+choose a category from [happy, frustrated, neutral, confused, angry].
+Return your result as JSON with `score` and `category`.
+Feedback: "{feedback_text}"
+```
+
+### Generic Issue Summarizer
+```
+Summarize the main issues mentioned in the following feedback.
+Provide short bullet points with suggested improvements.
+Input: "{feedback_text}"
+```
+
+These prompts can be adapted for Gemini, GPT, or any other large language model in your stack.


### PR DESCRIPTION
## Summary
- document an emotional/NLM pipeline for customer feedback
- show sample prompts for Gemini or other models

## Testing
- `npm run lint` *(fails: ESLint couldn't find a config)*

------
https://chatgpt.com/codex/tasks/task_b_6844e9e43b348332b57473fa787e0df9

## Summary by Sourcery

Document the natural language feedback pipeline by adding a new README with steps for ingestion, preprocessing, emotion scoring, issue classification, storage, and sample prompts.

Documentation:
- Add README.nlm.md outlining the NLM pipeline for customer feedback analysis.
- Include sample prompts for sentiment scoring and issue summarization with large language models.