### PR TITLE
Add google-generativeai support

### DIFF
--- a/data/logger/README.md
+++ b/data/logger/README.md
@@ -2,6 +2,16 @@
 
 This directory stores operational logs used by the pricing and KPI system. Every log must be a JSON file that conforms to the schema below. Files that fail validation will be rejected by downstream modules. The validation script requires **Python 3.8+**.
 
+## Installation
+
+Install Python dependencies with:
+
+```bash
+pip install -r requirements.txt
+```
+
+The `summarize_logs.py` script depends on the `google-generativeai` package and requires the `GEMINI_API_KEY` environment variable for access to the Gemini API.
+
 ## Required Fields
 
 | Field | Type | Description |

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,2 @@
 pytest>=6.0
+google-generativeai>=0.5.0


### PR DESCRIPTION
## Summary
- install `google-generativeai` in `requirements.txt`
- document how to install dependencies for the logger and mention `GEMINI_API_KEY`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_6847aa428438833288b2677dfda5b199

## Summary by Sourcery

Add support for Google Generative AI by installing the google-generativeai package and updating the logger documentation.

New Features:
- Include google-generativeai package in requirements and require GEMINI_API_KEY for API access.

Documentation:
- Add installation instructions and GEMINI_API_KEY note to data/logger README.